### PR TITLE
0.12: context feature; profile tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - context system: allow to specify suffix tokens on launchers name to filter
   their visiblity based on the system context on runtime.
 - cli: allow to specify profile to run/resolve as file paths
+- launchers: add `priority` key to let kloch guess which launcher to use
+  when a profile has multiple of them.
 
 ### changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2024-11-??
+
+### added
+
+- context system: allow to specify suffix tokens on launchers name to filter
+  their visiblity based on the system context on runtime.
+- cli: allow to specify profile to run/resolve as file paths
+
+### changed
+
+- ! `@python` launcher renamed to `.python` because of the new context system
+- ! `system` launcher renamed to `.system` for cohesion
+  - updated profile version to 4
+- ! system launcher: add subprocess_kwargs field, shell=True is not default anymore.
+- improve error reporting when a launcher is invalid
+- minor logging improvements
+
+### fixed
+
+- issues when picking a launcher through multiple in a profile
+
 ## [0.11.2] - 2024-10-26
 
 Add PyPI install instructions in documentation.

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,7 @@ Collection of various ideas to improve kloch.
 
 ## features
 
+- [ ] allow to create "on-the-fly" profile directly from the command line
 - [ ] allow to specify an absolute path to a profile instead of identifier
 - [ ] allow multiples arg in `inherit`
 - [ ] do something with the version attribute ? allow duplicate identifier in path, but with different version ?

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ Collection of various ideas to improve kloch.
   - [ ] PROFILE_DIR token
   - [ ] environment variable resolving ?
 - [ ] 🟡 allow `python_file` to be an url to a python file to download
-- [ ] 🟠 introduce operating system functions ? like maybe tokens or if conditions ?
+- [x] ~~🟠 introduce operating system functions ? like maybe tokens or if conditions ?~~
 - [x] ~~🔴 allow to specify an absolute path to a profile instead of identifier~~
 - [x] ~~log on disk ?~~
 - [x] ~~validation of keys/value on profile read~~

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,6 @@ Collection of various ideas to improve kloch.
 ## features
 
 - [ ] 🔴 allow to create "on-the-fly" profile directly from the command line
-- [ ] 🔴 allow to specify an absolute path to a profile instead of identifier
 - [ ] 🟠 allow multiples arg in `inherit`
 - [ ] 🟠 do something with the version attribute ? allow duplicate identifier in path, but with different version ?
 - [ ] 🟡 private profiles ? with a dot prefix signifying they can only be inherited and not used directly ?
@@ -23,6 +22,7 @@ Collection of various ideas to improve kloch.
   - [ ] environment variable resolving ?
 - [ ] 🟡 allow `python_file` to be an url to a python file to download
 - [ ] 🟠 introduce operating system functions ? like maybe tokens or if conditions ?
+- [x] ~~🔴 allow to specify an absolute path to a profile instead of identifier~~
 - [x] ~~log on disk ?~~
 - [x] ~~validation of keys/value on profile read~~
 - [x] ~~add a "python/pip/poetry" package manager ?~~ (implemented as launcher with kiche)

--- a/TODO.md
+++ b/TODO.md
@@ -2,19 +2,27 @@
 
 Collection of various ideas to improve kloch.
 
+| icon  | priority |
+|-------|----------|
+| 🔴    | high     |
+| 🟠    | medium   |
+| 🟡    | normal   |
+| ⚪     | unsure   |
+
+
 ## features
 
-- [ ] allow to create "on-the-fly" profile directly from the command line
-- [ ] allow to specify an absolute path to a profile instead of identifier
-- [ ] allow multiples arg in `inherit`
-- [ ] do something with the version attribute ? allow duplicate identifier in path, but with different version ?
-- [ ] private profiles ? with a dot prefix signifying they can only be inherited and not used directly ?
-- [ ] set cwd for relative paths
-- [ ] token replacement system ?
+- [ ] 🔴 allow to create "on-the-fly" profile directly from the command line
+- [ ] 🔴 allow to specify an absolute path to a profile instead of identifier
+- [ ] 🟠 allow multiples arg in `inherit`
+- [ ] 🟠 do something with the version attribute ? allow duplicate identifier in path, but with different version ?
+- [ ] 🟡 private profiles ? with a dot prefix signifying they can only be inherited and not used directly ?
+- [ ] ⚪ set cwd for relative paths
+- [ ] ⚪ token replacement system ?
   - [ ] PROFILE_DIR token
   - [ ] environment variable resolving ?
-- [ ] allow `python_file` to be an url to a python file to download
-- [ ] introduce operating system functions ? like maybe tokens or if conditions ?
+- [ ] 🟡 allow `python_file` to be an url to a python file to download
+- [ ] 🟠 introduce operating system functions ? like maybe tokens or if conditions ?
 - [x] ~~log on disk ?~~
 - [x] ~~validation of keys/value on profile read~~
 - [x] ~~add a "python/pip/poetry" package manager ?~~ (implemented as launcher with kiche)
@@ -23,7 +31,7 @@ Collection of various ideas to improve kloch.
 
 ## refacto
 
-- [ ] ensure environment can be reproducible
+- [ ] ⚪ ensure environment can be reproducible
   - always store them as an intermediate resolved file before execution ?
   - remove all resolving from launcher and perform all of this upstream ?
   - store intermediate resolved file at user-defined location OR tmp location ?
@@ -33,7 +41,7 @@ Collection of various ideas to improve kloch.
   - perhaps its too complicated to achieve, so achieve a middle ground, where
     you resolve the requirements formulated in the profile and store them on disk,
     (code at Serialized level) then use that file to launch.
-- [ ] abstract `subprocess.run` in BaseLauncher and offer a `prepare_execution`
+- [ ] ⚪ abstract `subprocess.run` in BaseLauncher and offer a `prepare_execution`
   abstractmethod instead.
 - [x] ~~naming of thing ? package manager could just be "launchers"~~
 - [x] ~~internalise PyYaml dependenciyes (add it to vendor module)~~ (impossible) 

--- a/doc/source/_injected/demo-fileformat/exec-merge.py
+++ b/doc/source/_injected/demo-fileformat/exec-merge.py
@@ -1,10 +1,19 @@
 from pathlib import Path
 
-import kloch
+import subprocess
 
 THISDIR = Path(".", "source", "_injected", "demo-fileformat").absolute()
 
-profile_path = THISDIR / "profile.yml"
-profile = kloch.read_profile_from_file(profile_path, profile_locations=[THISDIR])
-profile = profile.get_merged_profile()
-print(kloch.serialize_profile(profile))
+result = subprocess.run(
+    [
+        "kloch",
+        "resolve",
+        "knots:echoes",
+        "--profile_roots",
+        str(THISDIR),
+        "--skip-context-filtering",
+    ],
+    capture_output=True,
+    text=True,
+)
+print(result.stdout)

--- a/doc/source/_injected/demo-fileformat/profile-beta.yml
+++ b/doc/source/_injected/demo-fileformat/profile-beta.yml
@@ -2,16 +2,15 @@ __magic__: kloch_profile:4
 identifier: knots:echoes:beta
 version: 0.3.2
 launchers:
-  +=rezenv:
-    +=config:
-      quiet: false
-      package_filter:
-        - excludes:
-            - glob(*.dev)
-    +=requires:
-      houdini: 20.1
-      maya: 2023
-      devUtils: 1+
+  .base:
     environ:
       PROD_STATUS: beta
       PROD_NAME: echoes
+  rezenv:
+    requires:
+      houdini: 20.1
+      maya: 2023
+      devUtils: 1+
+  rezenv@os=windows:
+    config:
+      default_shell: "powershell"

--- a/doc/source/_injected/demo-fileformat/profile-beta.yml
+++ b/doc/source/_injected/demo-fileformat/profile-beta.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: knots:echoes:beta
 version: 0.3.2
 launchers:

--- a/doc/source/_injected/demo-fileformat/profile.yml
+++ b/doc/source/_injected/demo-fileformat/profile.yml
@@ -3,15 +3,10 @@ identifier: knots:echoes
 version: 0.2.0
 inherit: knots:echoes:beta
 launchers:
-  +=rezenv:
-    +=config:
-      +=package_filter:
-        - excludes:
-            - after(1714574770)
-    +=params:
-      - --verbose
-    +=requires:
+  .base:
+    environ:
+      PROD_STATUS: prod
+  rezenv:
+    requires:
       houdini: 20.2
       -=devUtils: _
-    +=environ:
-      PROD_STATUS: prod

--- a/doc/source/_injected/demo-fileformat/profile.yml
+++ b/doc/source/_injected/demo-fileformat/profile.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: knots:echoes
 version: 0.2.0
 inherit: knots:echoes:beta

--- a/doc/source/_injected/demo-usage-.base/profile-a.yml
+++ b/doc/source/_injected/demo-usage-.base/profile-a.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: myStudio
 version: 0.1.0
 launchers:

--- a/doc/source/_injected/demo-usage-.base/profile-b.yml
+++ b/doc/source/_injected/demo-usage-.base/profile-b.yml
@@ -9,6 +9,6 @@ launchers:
   system:
     command:
       - diagnose
-  '#python':
+  .python:
     cwd: $STUDIO_COMMON_TOOLS_PATH
     python_file: ./diagnose.py

--- a/doc/source/_injected/demo-usage-.base/profile-b.yml
+++ b/doc/source/_injected/demo-usage-.base/profile-b.yml
@@ -9,6 +9,6 @@ launchers:
   system:
     command:
       - diagnose
-  '@python':
+  '#python':
     cwd: $STUDIO_COMMON_TOOLS_PATH
     python_file: ./diagnose.py

--- a/doc/source/_injected/demo-usage-.base/profile-b.yml
+++ b/doc/source/_injected/demo-usage-.base/profile-b.yml
@@ -6,7 +6,7 @@ launchers:
   .base:
     environ:
       LOG_LEVEL: DEBUG
-  system:
+  .system:
     command:
       - diagnose
   .python:

--- a/doc/source/_injected/demo-usage-.base/profile-b.yml
+++ b/doc/source/_injected/demo-usage-.base/profile-b.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: diagnose
 inherit: myStudio
 version: 0.1.0

--- a/doc/source/_injected/demo-usage-basics/profile.yml
+++ b/doc/source/_injected/demo-usage-basics/profile.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: myMovie
 version: 0.1.0
 launchers:

--- a/doc/source/_injected/demo-usage-standard/profile-a.yml
+++ b/doc/source/_injected/demo-usage-standard/profile-a.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: myStudio
 version: 0.1.0
 launchers:

--- a/doc/source/_injected/demo-usage-standard/profile-b.yml
+++ b/doc/source/_injected/demo-usage-standard/profile-b.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: myMovie
 inherit: myStudio
 version: 0.1.0

--- a/doc/source/_injected/demo-usage-tokens/profile-a.yml
+++ b/doc/source/_injected/demo-usage-tokens/profile-a.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: myMovie:beta
 version: 0.1.0
 launchers:

--- a/doc/source/_injected/demo-usage-tokens/profile-b.yml
+++ b/doc/source/_injected/demo-usage-tokens/profile-b.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: myMovie
 inherit: myMovie:beta
 version: 0.1.0

--- a/doc/source/_injected/demo-usage-tokens/profile-c.yml
+++ b/doc/source/_injected/demo-usage-tokens/profile-c.yml
@@ -1,0 +1,11 @@
+__magic__: kloch_profile:3
+identifier: greetings
+version: 0.1.0
+launchers:
+  .base:
+    environ:
+      BASE_GREETING: "hello"
+  system@os=windows:
+    command: powershell -c "echo $Env:BASE_GREETING there 👋"
+  system@os=linux:
+    command: sh -c "echo $BASE_GREETING there 👋"

--- a/doc/source/_injected/demo-usage-tokens/profile-c.yml
+++ b/doc/source/_injected/demo-usage-tokens/profile-c.yml
@@ -5,7 +5,7 @@ launchers:
   .base:
     environ:
       BASE_GREETING: "hello"
-  system@os=windows:
+  .system@os=windows:
     command: powershell -c "echo $Env:BASE_GREETING there 👋"
-  system@os=linux:
+  .system@os=linux:
     command: sh -c "echo $BASE_GREETING there 👋"

--- a/doc/source/_injected/demo-usage-tokens/profile-c.yml
+++ b/doc/source/_injected/demo-usage-tokens/profile-c.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: greetings
 version: 0.1.0
 launchers:

--- a/doc/source/_injected/exec-fileformat-token-context.py
+++ b/doc/source/_injected/exec-fileformat-token-context.py
@@ -1,0 +1,57 @@
+from kloch.launchers._context import _FIELDS_MAPPING
+
+RowType = tuple[str, str, str]
+
+
+def enforce_col_length(
+    row: tuple[str, str, str],
+    lengths: list[int],
+) -> RowType:
+    # noinspection PyTypeChecker
+    return tuple(
+        col.ljust(lengths[index], col[-1] if col else " ")
+        for index, col in enumerate(row)
+    )
+
+
+def unify_columns(table: list[RowType]) -> list[str]:
+    """
+    Add the columns separator to return a row string.
+    """
+    new_table = []
+    for row in table:
+        sep = "+" if row[-1][-1] in ["-", "="] else "|"
+        row = sep + sep.join(row) + sep
+        new_table.append(row)
+    return new_table
+
+
+def generate_table():
+    fields_table: list[RowType] = []
+    for prop_name, field in _FIELDS_MAPPING.items():
+        field_doc = field.metadata["doc"]
+        fields_table += [
+            (
+                f" ``{prop_name}`` ",
+                f" {field_doc['value']} ",
+                f" {field_doc['description']} ",
+            ),
+            ("-", "-", "-"),
+        ]
+
+    header_table = [
+        ("-", "-", "-"),
+        (" property name ", " property value ", " description "),
+        ("=", "=", "="),
+    ]
+    table = header_table + fields_table
+
+    col_lens = [max([len(row[index]) for row in table]) for index in range(3)]
+
+    table = [enforce_col_length(row, col_lens) for row in table]
+    table = unify_columns(table)
+
+    return "\n".join(table)
+
+
+print(generate_table())

--- a/doc/source/file-format.rst
+++ b/doc/source/file-format.rst
@@ -142,7 +142,7 @@ Context tokens are then used with the following logic:
 
 - when reading a profile, a context is created from the current system.
 - this context is used to **filter out** launcher which doesn't match it.
-   - example: ``system@os=linux: ...`` will be deleted if the current os = windows.
+   - example: ``.system@os=linux: ...`` will be deleted if the current os = windows.
 - the remaining launchers which points to the same launcher are then merged
   from top to bottom using the same Merge Tokens logic, thus leaving only
   a launcher name with no context token at the end.
@@ -154,7 +154,7 @@ Example:
 
 In the above example we use the builtin system launcher to run a different
 command depending on the operating system. Make note that if the os is ``mac``
-then this mean the ``system`` launcher will just not exist at all in the profile !
+then this mean the ``.system`` launcher will just not exist at all in the profile !
 
 Launchers
 ---------

--- a/doc/source/file-format.rst
+++ b/doc/source/file-format.rst
@@ -105,6 +105,56 @@ Here is an example making use of all of the tokens and the python API used to me
    :filename: _injected/exec-fileformat-token-append.py
    :language_output: python
 
+Context Tokens
+______________
+
+Those tokens are exclusive to the launcher's name key and allow to
+specify for which system context the launcher must be used. This allow you
+for example to have a same launcher with 2 different configuration depending
+on the operating system.
+
+A context token:
+
+- MUST only appear in the ``{launcher name}`` key
+- MUST be suffixed to the launcher name
+- CAN be optional
+
+A context have several property, to declare which properties the launcher
+must match you use the following syntax:
+
+.. code-block:: bash
+
+   @{property name}={property value}
+   # multiple properties can be chained
+   @{property name}={property value}@{property name}={property value}@...
+
+.. tip::
+
+   If you need the literal ``@`` character in the launcher name or in the
+   properties values you can escape it by doubling it like ``@@``.
+
+The following context properties are availables:
+
+.. exec-inject::
+   :filename: _injected/exec-fileformat-token-context.py
+
+Context tokens are then used with the following logic:
+
+- when reading a profile, a context is created from the current system.
+- this context is used to **filter out** launcher which doesn't match it.
+   - example: ``system@os=linux: ...`` will be deleted if the current os = windows.
+- the remaining launchers which points to the same launcher are then merged
+  from top to bottom using the same Merge Tokens logic, thus leaving only
+  a launcher name with no context token at the end.
+
+Example:
+
+.. literalinclude:: _injected/demo-usage-tokens/profile-c.yml
+  :language: YAML
+
+In the above example we use the builtin system launcher to run a different
+command depending on the operating system. Make note that if the os is ``mac``
+then this mean the ``system`` launcher will just not exist at all in the profile !
 
 Launchers
 ---------

--- a/doc/source/file-format.rst
+++ b/doc/source/file-format.rst
@@ -212,7 +212,7 @@ We execute the following command:
 
 .. code-block:: shell
 
-   kloch resolve knots:echoes --profile_roots ./profiles/
+   kloch resolve knots:echoes --profile_roots ./profiles/ --skip-context-filtering
 
 .. exec_code::
    :hide_code:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,9 +12,20 @@ Configurations are `yaml <https://en.wikipedia.org/wiki/YAML>`_ files referred
 as `environment profile` which specify the parameters for one or
 multiple pre-defined launchers.
 
-.. literalinclude:: _injected/demo-fileformat/profile.yml
-   :language: yaml
-   :caption: a profile with the configuration for a `rezenv` launcher which inherit another profile
+.. container:: columns
+
+   .. container:: column-left
+
+      .. literalinclude:: _injected/demo-fileformat/profile-beta.yml
+         :language: yaml
+         :caption: ./profiles/beta.yml
+
+   .. container:: column-right
+
+      .. literalinclude:: _injected/demo-fileformat/profile.yml
+         :language: yaml
+         :caption: ./profiles/prod.yml
+
 
 `Launchers` are internally-defined python objects that specify how to execute
 a combinations of options and (optional) command.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -14,7 +14,7 @@ multiple pre-defined launchers.
 
 .. literalinclude:: _injected/demo-fileformat/profile.yml
    :language: yaml
-   :caption: a profile with the configuration for a `rezenv` launcher
+   :caption: a profile with the configuration for a `rezenv` launcher which inherit another profile
 
 `Launchers` are internally-defined python objects that specify how to execute
 a combinations of options and (optional) command.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -1,7 +1,7 @@
 Install
 =======
 
-`kloch` is a python-based tool with ``PyYaml`` as only dependency.
+`kloch` is a python-based tool with ``PyYAML`` as only dependency.
 
 It's available on `PyPI <https://pypi.org/project/kloch>`_ and can be installed
 with:
@@ -15,3 +15,33 @@ If you use poetry you can also include it in your project as a git dependency
 .. code-block:: shell
 
    poetry add "git+https://github.com/knotsanimation/kloch.git"
+
+the manual way
+--------------
+
+If you don't like all that mess that is the python packaging ecosystem nothing
+prevent you to go with a more low-level approach.
+
+You can copy the ``kloch`` directory (the one with an ``__init__.py`` inside)
+at any location that is registred in your PYTHONPATH env var.
+
+You just need to ensure PyYAML is also downloaded and accessible in your PYTHONPATH.
+
+Assuming ``python`` is available you coudl use the following recipe:
+
+.. code-block:: shell
+   :caption: shell script
+
+   install_dir="/d/demo"
+   mkdir $install_dir
+
+   cd ./tmp
+   git clone https://github.com/knotsanimation/kloch.git
+   cp --recursive ./kloch/kloch "$install_dir/kloch"
+   # we should now have /d/demo/kloch/__init__.py
+
+   python -m pip install PyYAML --target "$install_dir"
+
+   export PYTHONPATH="$install_dir"
+   python -m kloch --help
+

--- a/doc/source/public-api/launchers.rst
+++ b/doc/source/public-api/launchers.rst
@@ -5,6 +5,18 @@ Launchers
 
    import kloch.launchers
 
+Contexts
+--------
+
+.. autoclass:: kloch.launchers.LauncherContext
+   :members:
+   :undoc-members:
+
+.. autoclass:: kloch.launchers.LauncherPlatform
+   :members:
+   :undoc-members:
+
+
 Getters
 -------
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -274,7 +274,7 @@ Which once merged internally by kloch will produce a ``launchers`` structure lik
    :language_output: yaml
 
 As you can view, we inherit the ``environ`` keys that were defined in the
-``.base`` launcher (that is deleted) for both ``system`` and ``.python`` launchers.
+``.base`` launcher (that is deleted) for both ``.system`` and ``.python`` launchers.
 
 It is also good to notice that we define environment variable that re-use previously
 defined environment variable, at profile level or system level (``$PATH``).
@@ -293,7 +293,7 @@ being which operating system it is currently running on.
 .. literalinclude:: _injected/demo-usage-tokens/profile-c.yml
   :language: YAML
 
-In the above example we use the builtin system launcher to run a different
+In the above example we use the builtin .system launcher to run a different
 command depending on the operating system.
 
 Storing profiles

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -280,6 +280,22 @@ It is also good to notice that we define environment variable that re-use previo
 defined environment variable, at profile level or system level (``$PATH``).
 
 
+supporting different os
+_______________________
+
+You can create conditional behavior in your profile by using `Context tokens`
+(explained in :doc:`file-format`).
+
+This token allow you to restrict the "visibility" of a launcher only when
+the system reading the profile reach some conditions. The most common one
+being which operating system it is currently running on.
+
+.. literalinclude:: _injected/demo-usage-tokens/profile-c.yml
+  :language: YAML
+
+In the above example we use the builtin system launcher to run a different
+command depending on the operating system.
+
 Storing profiles
 ________________
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -274,7 +274,7 @@ Which once merged internally by kloch will produce a ``launchers`` structure lik
    :language_output: yaml
 
 As you can view, we inherit the ``environ`` keys that were defined in the
-``.base`` launcher (that is deleted) for both ``system`` and ``@python`` launchers.
+``.base`` launcher (that is deleted) for both ``system`` and ``#python`` launchers.
 
 It is also good to notice that we define environment variable that re-use previously
 defined environment variable, at profile level or system level (``$PATH``).

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -93,7 +93,8 @@ imply we will be using ``kloch`` as a `Command Line Interface` tool [2]_.
    :hide_code:
    :filename: _injected/demo-usage-basics/exec-list.py
 
-All good, which mean we can use our profile using the ``run`` command:
+All good, which mean we can use our profile using the ``run`` command and
+by giving it the **identifier** of the desire profile to launch:
 
 .. tip::
 
@@ -102,6 +103,15 @@ All good, which mean we can use our profile using the ``run`` command:
 .. code-block:: shell
 
    python -m kloch run myMovie
+
+Instead of providing the profile identifier, you can also provide a path
+to an existing profile file, that may not even be registred in a profile
+root !
+
+.. code-block:: shell
+
+   python -m kloch run /d/pipeline/profiles/basic-profile.yml
+
 
 Which in our case should start a rez interactive shell.
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -274,7 +274,7 @@ Which once merged internally by kloch will produce a ``launchers`` structure lik
    :language_output: yaml
 
 As you can view, we inherit the ``environ`` keys that were defined in the
-``.base`` launcher (that is deleted) for both ``system`` and ``#python`` launchers.
+``.base`` launcher (that is deleted) for both ``system`` and ``.python`` launchers.
 
 It is also good to notice that we define environment variable that re-use previously
 defined environment variable, at profile level or system level (``$PATH``).

--- a/kloch/__init__.py
+++ b/kloch/__init__.py
@@ -40,4 +40,4 @@ from .cli import get_cli
 from .cli import run_cli
 
 # keep in sync with pyproject.toml
-__version__ = "0.11.2"
+__version__ = "0.12.0"

--- a/kloch/cli.py
+++ b/kloch/cli.py
@@ -241,8 +241,6 @@ class RunParser(BaseParser):
 
         print(f"starting launcher {launcher.name}")
         LOGGER.debug(f"executing launcher={launcher} with command={command}")
-        LOGGER.debug(f"os.environ={json.dumps(dict(os.environ), indent=4)}")
-
         sys.exit(launcher.execute(tmpdir=session_dir.path, command=command))
 
     def execute(self):
@@ -544,7 +542,10 @@ def _get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_cli(argv: Optional[List[str]] = None, config: kloch.KlochConfig = None) -> BaseParser:
+def get_cli(
+    argv: Optional[List[str]] = None,
+    config: kloch.KlochConfig = None,
+) -> BaseParser:
     """
     Return the command line interface generated from user arguments provided.
 

--- a/kloch/cli.py
+++ b/kloch/cli.py
@@ -226,7 +226,16 @@ class RunParser(BaseParser):
                 sys.exit(112)
 
         launcher_serial: BaseLauncherSerialized = launchers_list[0]
-        launcher_serial.validate()
+        try:
+            launcher_serial.validate()
+        except AssertionError as error:
+            print(
+                f"ERROR | Cannot validate launcher '{launcher_serial.identifier}' from profile '{profile.identifier}': "
+                f"{error}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
         launcher: BaseLauncher = launcher_serial.unserialize()
         command = self.command or None
 

--- a/kloch/cli.py
+++ b/kloch/cli.py
@@ -40,7 +40,7 @@ class BaseParser:
         self,
         args: argparse.Namespace,
         config: kloch.KlochConfig,
-        original_argv: list[str],
+        original_argv: List[str],
     ):
         self._args: argparse.Namespace = args
         self._config = config

--- a/kloch/cli.py
+++ b/kloch/cli.py
@@ -210,20 +210,20 @@ class RunParser(BaseParser):
                     f"<{self.profile_ids}>: you need to specify a launcher name with --launcher",
                     file=sys.stderr,
                 )
-                sys.exit(1)
+                sys.exit(111)
 
-            launchers_dict = [
+            launchers_list = [
                 _launcher
                 for _launcher in launchers_list
-                if _launcher.name == self.launcher
+                if _launcher.identifier == self.launcher
             ]
-            if not launchers_dict:
+            if not launchers_list:
                 print(
                     f"ERROR | No launcher with name <{self.launcher}> "
                     f"found in profile <{self.profile_ids}>",
                     file=sys.stderr,
                 )
-                sys.exit(1)
+                sys.exit(112)
 
         launcher_serial: BaseLauncherSerialized = launchers_list[0]
         launcher_serial.validate()

--- a/kloch/cli.py
+++ b/kloch/cli.py
@@ -100,10 +100,15 @@ class BaseParser:
 
         profiles = []
         for profile_id in profile_identifiers:
-            profile_paths = kloch.get_profile_file_path(
-                profile_id,
-                profile_locations=profile_locations,
-            )
+
+            aspath = Path(profile_id)
+            if aspath.exists():
+                profile_paths = [aspath]
+            else:
+                profile_paths = kloch.get_profile_file_path(
+                    profile_id,
+                    profile_locations=profile_locations,
+                )
             if len(profile_paths) >= 2:
                 print(
                     f"ERROR | Found multiple profile with identifier '{profile_id}' "
@@ -164,7 +169,8 @@ class RunParser(BaseParser):
     @property
     def profile_ids(self) -> List[str]:
         """
-        One or more identifier of existing environment profile(s).
+        One or more identifier or file paths of existing environment profile(s).
+
         The profiles are concatenated together from left to right.
         """
         return self._args.profile_ids
@@ -239,8 +245,8 @@ class RunParser(BaseParser):
         launcher: BaseLauncher = launcher_serial.unserialize()
         command = self.command or None
 
-        print(f"starting launcher {launcher.name}")
         LOGGER.debug(f"executing launcher={launcher} with command={command}")
+        print(f"starting launcher {launcher.name}")
         sys.exit(launcher.execute(tmpdir=session_dir.path, command=command))
 
     def execute(self):
@@ -350,7 +356,8 @@ class ResolveParser(BaseParser):
     @property
     def profile_ids(self) -> List[str]:
         """
-        One or more identifier of existing environment profile(s).
+        One or more identifier or file paths of existing environment profile(s).
+
         The profiles are concatenated together from left to right.
         """
         return self._args.profile_ids

--- a/kloch/filesyntax/_io.py
+++ b/kloch/filesyntax/_io.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 KENV_PROFILE_MAGIC = "kloch_profile"
-KENV_PROFILE_VERSION = 3
+KENV_PROFILE_VERSION = 4
 
 
 class ProfileAPIVersionError(Exception):

--- a/kloch/filesyntax/_io.py
+++ b/kloch/filesyntax/_io.py
@@ -228,6 +228,7 @@ def write_profile_to_file(
     file_path: Path,
     profile_locations: Optional[List[Path]] = None,
     check_valid_id: bool = True,
+    extra_comments: List[str] = None,
 ) -> Path:
     """
     Convert the instance to a serialized file on disk.
@@ -244,6 +245,7 @@ def write_profile_to_file(
             if True, ensure the identifier of the profile is unique among all ``profile_locations``
         profile_locations:
             list of filesystem path to potential existing directories containing profiles.
+        extra_comments: optional lines of comments to put in the yaml header
     """
     if check_valid_id:
         profile_paths = get_profile_file_path(
@@ -256,6 +258,10 @@ def write_profile_to_file(
             )
 
     serialized = serialize_profile(profile, profile_locations=profile_locations)
+
+    extra_comments = extra_comments or []
+    extra_comments = "# " + "\n# ".join(extra_comments)
+    serialized = extra_comments + "\n" + serialized
 
     file_path.write_text(serialized)
     return file_path

--- a/kloch/launchers/__init__.py
+++ b/kloch/launchers/__init__.py
@@ -2,6 +2,9 @@
 Entities that serialize a function call made to execute a software.
 """
 
+from ._context import LauncherContext
+from ._context import LauncherPlatform
+
 from .base import BaseLauncher
 from .base import BaseLauncherSerialized
 from .base import BaseLauncherFields

--- a/kloch/launchers/_context.py
+++ b/kloch/launchers/_context.py
@@ -1,0 +1,200 @@
+import dataclasses
+import enum
+import getpass
+import logging
+import sys
+from typing import Dict
+from typing import Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LauncherPlatform(enum.Flag):
+    """
+    Operating Systems that a launcher may support.
+    """
+
+    linux = enum.auto()
+    darwin = enum.auto()
+    windows = enum.auto()
+
+    @classmethod
+    def current(cls):
+        """
+        Get the member corresponding to the current runtime operating system.
+        """
+        current = sys.platform
+        if current.startswith("linux"):
+            return cls.linux
+        if current.startswith("darwin"):
+            return cls.darwin
+        if current in ("win32", "cygwin"):
+            return cls.windows
+
+        raise OSError(f"Unsupported operating system '{current}'")
+
+    def is_linux(self) -> bool:
+        return self == self.linux
+
+    def is_mac(self) -> bool:
+        return self == self.darwin
+
+    def is_windows(self) -> bool:
+        return self == self.windows
+
+
+_PLATFORM_MAPPING = {
+    "linux": LauncherPlatform.linux,
+    "windows": LauncherPlatform.windows,
+    "mac": LauncherPlatform.darwin,
+}
+"""
+Mapping of serialized platform names to their corresponding enum instance.
+"""
+
+
+@dataclasses.dataclass
+class LauncherContext:
+    """
+    Collection of system-contextual values in which a profile is being parsed.
+
+    You can compare 2 context using the equal comparator however be aware that
+    a None value (implies unset) will be considered equal to any other value.
+
+    Example::
+
+         ctx1 = LauncherContext(platform=LauncherPlatform.linux, user="demo")
+         ctx2 = LauncherContext(platform=LauncherPlatform.linux, user=None)
+         assert ctx1 == ctx2
+
+    """
+
+    platform: Optional[LauncherPlatform] = dataclasses.field(
+        default=None,
+        metadata={
+            "serialized_name": "os",
+            "unserialize": lambda v: _PLATFORM_MAPPING[v],
+            "doc": {
+                "value": f"one of ``{'``, ``'.join(_PLATFORM_MAPPING.keys())}``",
+                "description": "name of the operating system",
+            },
+        },
+    )
+    """
+    name of the operating system
+    """
+
+    user: Optional[str] = dataclasses.field(
+        default=None,
+        metadata={
+            "serialized_name": "user",
+            "unserialize": str,
+            "doc": {
+                "value": f"arbitrary string",
+                "description": "name of the user",
+            },
+        },
+    )
+    """
+    name of the current user
+    """
+
+    def __str__(self) -> str:
+        return f"os={self.platform.name};user={self.user}"
+
+    def __eq__(self, other):
+        c = self.__class__
+        if not isinstance(other, c):
+            raise TypeError(f"Cannot concatenate {c} and {type(other)}")
+
+        for field in dataclasses.fields(c):
+            selfvalue = getattr(self, field.name)
+            othervalue = getattr(other, field.name)
+            # we discard the comparison when a field is not set
+            if selfvalue is None or othervalue is None:
+                continue
+
+            if selfvalue != othervalue:
+                return False
+
+        return True
+
+    @classmethod
+    def create_from_system(cls):
+        """
+        Fill the instance with values retrieved from the current system context.
+        """
+        return cls(
+            platform=LauncherPlatform.current(),
+            user=getpass.getuser(),
+        )
+
+
+_FIELDS_MAPPING: Dict[str, dataclasses.Field] = {
+    field.metadata["serialized_name"]: field
+    for field in dataclasses.fields(LauncherContext)
+}
+
+
+_ESCAPE_CHARACTER = "%!TMP}]"
+
+
+def _escape(source: str) -> str:
+    return source.replace("@@", _ESCAPE_CHARACTER)
+
+
+def _unescape(source: str) -> str:
+    return source.replace(_ESCAPE_CHARACTER, "@")
+
+
+def resolve_context_expression(source: str) -> str:
+    """
+    Remove the profile context expression from the given source string.
+    """
+    escaped = _escape(source)
+    if "@" not in escaped:
+        return _unescape(escaped)
+    return _unescape(source.split("@")[0])
+
+
+def unserialize_context_expression(source: str) -> LauncherContext:
+    """
+    Generate a profile context based on its serialized expression form.
+
+    The expression take the following pattern::
+
+        .(@key=value)*
+
+    Where ``.`` means any character, ``()*`` means it can be repated multiple times.
+
+    Args:
+        source:
+            abitrary string which contain an expression to unserialize,
+            may be an empty string.
+
+    Returns:
+        a new profile context instance (that may be empty).
+    """
+    escaped = _escape(source)
+
+    if "@" not in escaped:
+        return LauncherContext()
+
+    members = escaped.split("@")[1:]
+    asdict = {}
+
+    for member in members:
+        member = _unescape(member)
+        key, value = member.split("=")
+        field = _FIELDS_MAPPING.get(key)
+        if not field:
+            raise KeyError(
+                f"Unsupported context key name '{key}'; must one of {_FIELDS_MAPPING}"
+            )
+        field_name = field.name
+        unserialize = field.metadata["unserialize"]
+        # we explicitly allow a field to be defined multiple time,
+        # its last definition will take precedence in value.
+        asdict[field_name] = unserialize(value)
+
+    return LauncherContext(**asdict)

--- a/kloch/launchers/_serialized.py
+++ b/kloch/launchers/_serialized.py
@@ -4,6 +4,9 @@ from typing import List
 from typing import Type
 
 from kloch import MergeableDict
+from ._context import LauncherContext
+from ._context import unserialize_context_expression
+from ._context import resolve_context_expression
 from kloch.launchers import BaseLauncherSerialized
 
 
@@ -55,6 +58,42 @@ class LauncherSerializedDict(MergeableDict):
     See :any:`MergeableDict` for the full documentation on tokens.
     """
 
+    def get_filtered_context(
+        self, context: LauncherContext
+    ) -> "LauncherSerializedDict":
+        """
+        Remove all launchers that doesn't match the given context.
+
+        Returns:
+             a new deepcopied instance with possibly lesser keys.
+        """
+        newdict = copy.deepcopy(self)
+        for launcher_identifier in self.keys():
+            launcher_context = unserialize_context_expression(launcher_identifier)
+            if launcher_context != context:
+                del newdict[launcher_identifier]
+
+        return newdict
+
+    def with_context_resolved(self) -> "LauncherSerializedDict":
+        """
+        Merge all the same launchers with different contexts to a single launcher.
+        """
+        toconcatenate: list[LauncherSerializedDict] = []
+        for launcher_identifier in self.keys():
+            resolved = resolve_context_expression(launcher_identifier)
+            newdict = LauncherSerializedDict(
+                {resolved: copy.deepcopy(self[launcher_identifier])}
+            )
+            toconcatenate.append(newdict)
+
+        if len(toconcatenate) == 0:
+            return copy.deepcopy(self)
+        elif len(toconcatenate) == 1:
+            return toconcatenate[0]
+
+        return sum(toconcatenate[1:], toconcatenate[0])
+
     def to_serialized_list(
         self,
         launcher_classes: List[Type[BaseLauncherSerialized]],
@@ -78,6 +117,8 @@ class LauncherSerializedDict(MergeableDict):
         launchers = []
         for identifier, launcher_config in self.items():
             _identifier = self.resolve_key_tokens(identifier)
+            # it's not supposed to have context expression at this stage but we safe-proof it
+            _identifier = resolve_context_expression(_identifier)
             launcher_class = _launcher_classes.get(_identifier)
             if not launcher_class:
                 raise ValueError(

--- a/kloch/launchers/_serialized.py
+++ b/kloch/launchers/_serialized.py
@@ -79,7 +79,7 @@ class LauncherSerializedDict(MergeableDict):
         """
         Merge all the same launchers with different contexts to a single launcher.
         """
-        toconcatenate: list[LauncherSerializedDict] = []
+        toconcatenate: List[LauncherSerializedDict] = []
         for launcher_identifier in self.keys():
             resolved = resolve_context_expression(launcher_identifier)
             newdict = LauncherSerializedDict(

--- a/kloch/launchers/base/_dataclass.py
+++ b/kloch/launchers/base/_dataclass.py
@@ -38,6 +38,11 @@ class BaseLauncher:
     The developer is reponsible of honoring the field usage in its launcher implementation.
     """
 
+    priority: int = 0
+    """
+    How much you should privilege this launcher to be used over other launchers.
+    """
+
     required_fields: ClassVar[List[str]] = []
     """
     List of dataclass field that are required to have a non-None value when instancing.

--- a/kloch/launchers/base/_dataclass.py
+++ b/kloch/launchers/base/_dataclass.py
@@ -60,6 +60,23 @@ class BaseLauncher:
     A unique name among all subclasses.
     """
 
+    def __str__(self) -> str:
+        fields: List[str] = []
+        for field in dataclasses.fields(self):
+            name = field.name
+            value = getattr(self, name)
+            if name == "environ":
+                asstr = "{...}" if value else "{}"
+            elif name == "command":
+                asstr = "[...]" if value else "[]"
+            else:
+                asstr = str(value)
+
+            fields += [f"{name}={asstr}"]
+
+        fieldsstr = ", ".join(fields)
+        return f"<{self.__class__.__name__} {fieldsstr}>"
+
     def __post_init__(self):
         for field in dataclasses.fields(self):
             if field.name in self.required_fields and getattr(self, field.name) is None:

--- a/kloch/launchers/base/_serialized.py
+++ b/kloch/launchers/base/_serialized.py
@@ -137,6 +137,16 @@ class BaseLauncherFields:
             "required": False,
         },
     )
+    priority: int = dataclasses.field(
+        default="priority",
+        metadata={
+            "description": (
+                "How much you should privilege this launcher to be used over other launchers."
+                "Higher number means higher priority."
+            ),
+            "required": False,
+        },
+    )
 
     @classmethod
     def iterate(cls) -> List[dataclasses.Field]:
@@ -215,6 +225,10 @@ class BaseLauncherSerialized(MergeableDict):
                 assert isinstance(
                     value, str
                 ), f"'{command}': item '{value}' must be str."
+
+        priority = self.fields.priority
+        if priority in self:
+            assert isinstance(self[priority], int), f"'{priority}': must be an int."
 
     def resolved(self) -> Dict:
         """

--- a/kloch/launchers/python/_dataclass.py
+++ b/kloch/launchers/python/_dataclass.py
@@ -25,7 +25,7 @@ class PythonLauncher(BaseLauncher):
 
     required_fields = ["python_file"]
 
-    name = "#python"
+    name = ".python"
 
     def execute(self, tmpdir: Path, command: Optional[List[str]] = None):
         """

--- a/kloch/launchers/python/_dataclass.py
+++ b/kloch/launchers/python/_dataclass.py
@@ -25,7 +25,7 @@ class PythonLauncher(BaseLauncher):
 
     required_fields = ["python_file"]
 
-    name = "@python"
+    name = "#python"
 
     def execute(self, tmpdir: Path, command: Optional[List[str]] = None):
         """

--- a/kloch/launchers/python/_dataclass.py
+++ b/kloch/launchers/python/_dataclass.py
@@ -36,9 +36,7 @@ class PythonLauncher(BaseLauncher):
         _command = [sys.executable, self.python_file]
         _command += self.command + (command or [])
 
-        LOGGER.debug(
-            f"executing python command={_command}; environ={self.environ}; cwd={self.cwd}"
-        )
+        LOGGER.debug(f"subprocess.run({_command}, env={self.environ}, cwd={self.cwd})")
         result = subprocess.run(_command, env=self.environ, cwd=self.cwd)
 
         return result.returncode

--- a/kloch/launchers/system/_dataclass.py
+++ b/kloch/launchers/system/_dataclass.py
@@ -17,7 +17,7 @@ class SystemLauncher(BaseLauncher):
     A minimal launcher that just start a subprocess with the given command.
     """
 
-    name = "system"
+    name = ".system"
 
     subprocess_kwargs: dict = dataclasses.field(default_factory=dict)
     """

--- a/kloch/launchers/system/_dataclass.py
+++ b/kloch/launchers/system/_dataclass.py
@@ -26,7 +26,7 @@ class SystemLauncher(BaseLauncher):
         _command = self.command + (command or [])
 
         LOGGER.debug(
-            f"executing system command={_command}; environ={self.environ}; cwd={self.cwd}"
+            f"subprocess.run({_command}, shell=True, env={self.environ}, cwd={self.cwd})"
         )
         result = subprocess.run(_command, shell=True, env=self.environ, cwd=self.cwd)
 

--- a/kloch/launchers/system/_dataclass.py
+++ b/kloch/launchers/system/_dataclass.py
@@ -19,6 +19,11 @@ class SystemLauncher(BaseLauncher):
 
     name = "system"
 
+    subprocess_kwargs: dict = dataclasses.field(default_factory=dict)
+    """
+    Mapping of kwargs to pass to python's 'subprocess.run' call.
+    """
+
     def execute(self, tmpdir: Path, command: Optional[List[str]] = None):
         """
         Just call subprocess.run.
@@ -26,8 +31,13 @@ class SystemLauncher(BaseLauncher):
         _command = self.command + (command or [])
 
         LOGGER.debug(
-            f"subprocess.run({_command}, shell=True, env={self.environ}, cwd={self.cwd})"
+            f"subprocess.run({_command}, env={self.environ}, cwd={self.cwd}, **{self.subprocess_kwargs})"
         )
-        result = subprocess.run(_command, shell=True, env=self.environ, cwd=self.cwd)
+        result = subprocess.run(
+            _command,
+            env=self.environ,
+            cwd=self.cwd,
+            **self.subprocess_kwargs,
+        )
 
         return result.returncode

--- a/kloch/launchers/system/_serialized.py
+++ b/kloch/launchers/system/_serialized.py
@@ -10,7 +10,15 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclasses.dataclass(frozen=True)
 class SystemLauncherFields(BaseLauncherFields):
-    pass
+    subprocess_kwargs: dict = dataclasses.field(
+        default="subprocess_kwargs",
+        metadata={
+            "description": (
+                "Mapping of kwargs to pass to the internal ``subprocess.run`` call."
+            ),
+            "required": False,
+        },
+    )
 
 
 class SystemLauncherSerialized(BaseLauncherSerialized):
@@ -29,6 +37,11 @@ class SystemLauncherSerialized(BaseLauncherSerialized):
     )
 
     def validate(self):
+        subprocesskw = self.fields.subprocess_kwargs
+        if subprocesskw in self:
+            assert isinstance(
+                self[subprocesskw], dict
+            ), f"'{subprocesskw}': must be a dict."
         super().validate()
 
     # we override for type-hint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "kloch"
 # keep in sync with __init__.py
-version = "0.11.2"
+version = "0.12.0"
 description = "Environment Manager CLI wrapping package managers calls as serialized config file"
 authors = ["Liam Collod <monsieurlixm@gmail.com>"]
 readme = "README.md"

--- a/tests/data/e2e-1/profile.prod.yml
+++ b/tests/data/e2e-1/profile.prod.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: prod
 version: 0.1.0
 inherit: studio

--- a/tests/data/e2e-1/profile.prodml.yml
+++ b/tests/data/e2e-1/profile.prodml.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: prodml
 version: 0.1.0
 inherit: studio

--- a/tests/data/e2e-1/profile.prodml.yml
+++ b/tests/data/e2e-1/profile.prodml.yml
@@ -10,5 +10,6 @@ launchers:
     command:
       - echo
       - hello from
+  system@os=windows:
     subprocess_kwargs:
       shell: True

--- a/tests/data/e2e-1/profile.prodml.yml
+++ b/tests/data/e2e-1/profile.prodml.yml
@@ -9,7 +9,8 @@ launchers:
   system:
     command:
       - echo
-      - hello from
+      - hello
+      - from
   system@os=windows:
     subprocess_kwargs:
       shell: True

--- a/tests/data/e2e-1/profile.prodml.yml
+++ b/tests/data/e2e-1/profile.prodml.yml
@@ -6,11 +6,11 @@ launchers:
   .base:
     environ:
       PROD_NAME: "myprod"
-  system:
+  .system:
     command:
       - echo
       - hello
       - from
-  system@os=windows:
+  .system@os=windows:
     subprocess_kwargs:
       shell: True

--- a/tests/data/e2e-1/profile.prodml.yml
+++ b/tests/data/e2e-1/profile.prodml.yml
@@ -10,3 +10,5 @@ launchers:
     command:
       - echo
       - hello from
+    subprocess_kwargs:
+      shell: True

--- a/tests/data/e2e-1/profile.prodml.yml
+++ b/tests/data/e2e-1/profile.prodml.yml
@@ -1,0 +1,12 @@
+__magic__: kloch_profile:3
+identifier: prodml
+version: 0.1.0
+inherit: studio
+launchers:
+  .base:
+    environ:
+      PROD_NAME: "myprod"
+  system:
+    command:
+      - echo
+      - hello from

--- a/tests/data/e2e-1/profile.studio.yml
+++ b/tests/data/e2e-1/profile.studio.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: studio
 version: 0.1.0
 launchers:

--- a/tests/data/not-a-profile.txt
+++ b/tests/data/not-a-profile.txt
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: notaprofile
 version: 0.2.0
 launchers: {}

--- a/tests/data/profile.echoes-beta.yml
+++ b/tests/data/profile.echoes-beta.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: knots:echoes:beta
 version: 0.1.0
 launchers:

--- a/tests/data/profile.echoes.yml
+++ b/tests/data/profile.echoes.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: knots:echoes
 version: 0.2.0
 inherit: knots:echoes:beta

--- a/tests/data/profile.knots.yml
+++ b/tests/data/profile.knots.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: knots
 version: 0.1.0
 launchers:

--- a/tests/data/profile.lxm.yml
+++ b/tests/data/profile.lxm.yml
@@ -2,7 +2,7 @@ __magic__: kloch_profile:4
 identifier: lxm
 version: 0.1.0
 launchers:
-  +=#python:
+  +=.python:
     python_file: test-script-a.py
     environ:
       LXMCUSTOM: 1

--- a/tests/data/profile.lxm.yml
+++ b/tests/data/profile.lxm.yml
@@ -2,7 +2,7 @@ __magic__: kloch_profile:3
 identifier: lxm
 version: 0.1.0
 launchers:
-  +=@python:
+  +=#python:
     python_file: test-script-a.py
     environ:
       LXMCUSTOM: 1

--- a/tests/data/profile.lxm.yml
+++ b/tests/data/profile.lxm.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: lxm
 version: 0.1.0
 launchers:

--- a/tests/data/profile.mult-launchers.yml
+++ b/tests/data/profile.mult-launchers.yml
@@ -9,7 +9,7 @@ launchers:
     python_file: test-script-a.py
     environ:
       LXMCUSTOM: 1
-  system:
+  .system:
     environ:
       LXMCUSTOM: "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀"
       HEH: "(╯°□°）╯︵ ┻━┻)"

--- a/tests/data/profile.mult-launchers.yml
+++ b/tests/data/profile.mult-launchers.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: mult-launchers
 version: 0.1.0
 launchers:

--- a/tests/data/profile.mult-launchers.yml
+++ b/tests/data/profile.mult-launchers.yml
@@ -5,7 +5,7 @@ launchers:
   .base:
     environ:
       AYYYYY: "⭐"
-  '@python':
+  '#python':
     python_file: test-script-a.py
     environ:
       LXMCUSTOM: 1

--- a/tests/data/profile.mult-launchers.yml
+++ b/tests/data/profile.mult-launchers.yml
@@ -5,7 +5,7 @@ launchers:
   .base:
     environ:
       AYYYYY: "⭐"
-  '#python':
+  .python:
     python_file: test-script-a.py
     environ:
       LXMCUSTOM: 1

--- a/tests/data/profile.mult-launchers.yml
+++ b/tests/data/profile.mult-launchers.yml
@@ -1,0 +1,18 @@
+__magic__: kloch_profile:3
+identifier: mult-launchers
+version: 0.1.0
+launchers:
+  .base:
+    environ:
+      AYYYYY: "⭐"
+  '@python':
+    python_file: test-script-a.py
+    environ:
+      LXMCUSTOM: 1
+  system:
+    environ:
+      LXMCUSTOM: "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀"
+      HEH: "(╯°□°）╯︵ ┻━┻)"
+    command:
+      - paint.exe
+      - new

--- a/tests/data/profile.nolauncher.yml
+++ b/tests/data/profile.nolauncher.yml
@@ -1,0 +1,7 @@
+__magic__: kloch_profile:4
+identifier: nolauncher
+version: 0.1.0
+launchers:
+  .base:
+    environ:
+      TRANS_RIGHT_ARE_HUMAN_RIGHTS: why is there even the question in the first place

--- a/tests/data/profile.priorities-fail.yml
+++ b/tests/data/profile.priorities-fail.yml
@@ -1,0 +1,15 @@
+__magic__: kloch_profile:4
+identifier: priorities-fail
+version: 0.1.0
+launchers:
+  .system:
+    priority: 5
+    command:
+      - echo
+      - success_prio_test
+  .system@os=windows:
+    subprocess_kwargs:
+      shell: true
+  .python:
+    priority: 5
+    python_file: test-script-a.py

--- a/tests/data/profile.priorities-success.yml
+++ b/tests/data/profile.priorities-success.yml
@@ -1,0 +1,15 @@
+__magic__: kloch_profile:4
+identifier: priorities-success
+version: 0.1.0
+launchers:
+  .system:
+    priority: 5
+    command:
+      - echo
+      - success_prio_test
+  .system@os=windows:
+    subprocess_kwargs:
+      shell: true
+  .python:
+    priority: 3
+    python_file: test-script-a.py

--- a/tests/data/profile.system-test.yml
+++ b/tests/data/profile.system-test.yml
@@ -2,7 +2,7 @@ __magic__: kloch_profile:4
 identifier: system-test
 version: 0.1.0
 launchers:
-  +=system:
+  +=.system:
     environ:
       LXMCUSTOM: "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀"
       HEH: "(╯°□°）╯︵ ┻━┻)"

--- a/tests/data/profile.system-test.yml
+++ b/tests/data/profile.system-test.yml
@@ -1,4 +1,4 @@
-__magic__: kloch_profile:3
+__magic__: kloch_profile:4
 identifier: system-test
 version: 0.1.0
 launchers:

--- a/tests/data/profile.system-test.yml
+++ b/tests/data/profile.system-test.yml
@@ -9,3 +9,6 @@ launchers:
     command:
       - paint.exe
       - new
+    subprocess_kwargs:
+      shell: True
+      timeout: 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,33 @@ def test__getCli__run__command(monkeypatch, data_dir):
     assert Results.env["HEH"] == "(╯°□°）╯︵ ┻━┻)"
 
 
+def test__getCli__run__mult_launcher__error(monkeypatch, data_dir, capsys):
+    monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
+
+    argv = ["run", "mult-launchers"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="111"):
+        cli.execute()
+
+    argv = ["run", "mult-launchers", "--launcher", "BABABOEI!!"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="112"):
+        cli.execute()
+
+
+def test__getCli__run__mult_launcher(monkeypatch, data_dir, capfd):
+    monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
+    # needed to resolve 'python_file: test-script-a.py' in profile
+    monkeypatch.chdir(data_dir)
+    argv = ["run", "mult-launchers", "--launcher", "@python"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="0"):
+        cli.execute()
+
+    result = capfd.readouterr()
+    assert f"test script working" in result.out
+
+
 def test__getCli__python(data_dir, capsys):
     argv = ["python", str(data_dir / "test-script-a.py"), "some args ?", "test !"]
     cli = kloch.get_cli(argv=argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,7 +167,7 @@ def test__getCli__run__mult_launcher(monkeypatch, data_dir, capfd):
     monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
     # needed to resolve 'python_file: test-script-a.py' in profile
     monkeypatch.chdir(data_dir)
-    argv = ["run", "mult-launchers", "--launcher", "#python"]
+    argv = ["run", "mult-launchers", "--launcher", ".python"]
     cli = kloch.get_cli(argv=argv)
     with pytest.raises(SystemExit, match="0"):
         cli.execute()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,6 +176,52 @@ def test__getCli__run__mult_launcher(monkeypatch, data_dir, capfd):
     assert f"test script working" in result.out
 
 
+def test__getCli__run__priorities_success(monkeypatch, data_dir, capfd):
+    monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
+    # needed to resolve 'python_file: test-script-a.py' in profile
+    monkeypatch.chdir(data_dir)
+    argv = ["run", "priorities-success"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="0"):
+        cli.execute()
+
+    result = capfd.readouterr()
+    assert f"success_prio_test" in result.out
+
+
+def test__getCli__run__priorities_success__python(monkeypatch, data_dir, capfd):
+    monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
+    # needed to resolve 'python_file: test-script-a.py' in profile
+    monkeypatch.chdir(data_dir)
+    argv = ["run", "priorities-success", "--launcher", ".python"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="0"):
+        cli.execute()
+
+    result = capfd.readouterr()
+    assert f"{kloch.__name__} test script working" in result.out
+
+
+def test__getCli__run__priorities_fail(monkeypatch, data_dir, capfd):
+    monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
+    # needed to resolve 'python_file: test-script-a.py' in profile
+    monkeypatch.chdir(data_dir)
+    argv = ["run", "priorities-fail"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="111"):
+        cli.execute()
+
+
+def test__getCli__run__nolauncher(monkeypatch, data_dir, capfd):
+    monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
+    # needed to resolve 'python_file: test-script-a.py' in profile
+    monkeypatch.chdir(data_dir)
+    argv = ["run", "nolauncher"]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit, match="113"):
+        cli.execute()
+
+
 def test__getCli__python(data_dir, capsys):
     argv = ["python", str(data_dir / "test-script-a.py"), "some args ?", "test !"]
     cli = kloch.get_cli(argv=argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,7 @@ def test__getCli__list__profile_paths(data_dir, capsys):
     assert int(profile_capture.group(1)) >= 1
 
 
-def test__getCli__run(monkeypatch, data_dir):
+def test__getCli__run__lxm(monkeypatch, data_dir):
     import subprocess
 
     class Results:
@@ -99,7 +99,32 @@ def test__getCli__run(monkeypatch, data_dir):
     assert Results.env.get("LXMCUSTOM") == "1"
 
 
-def test__getCli__run__command(monkeypatch, data_dir):
+def test__getCli__run__lxm__aspath(monkeypatch, data_dir):
+    import subprocess
+
+    def patched_subprocess(command, env, *args, **kwargs):
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", patched_subprocess)
+
+    profile_path = data_dir / "profile.lxm.yml"
+
+    argv = ["run", str(profile_path)]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit) as error:
+        cli.execute()
+    assert not error.value.code
+
+    profile_path = data_dir / "profile.YEEEEEEHAWWW.yml"
+
+    argv = ["run", str(profile_path)]
+    cli = kloch.get_cli(argv=argv)
+    with pytest.raises(SystemExit) as error:
+        cli.execute()
+    assert error.value.code == 1
+
+
+def test__getCli__run__system_test__command(monkeypatch, data_dir):
     import subprocess
 
     class Results:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,7 @@ def test__getCli__run__system_test__command(monkeypatch, data_dir):
         command: List[str] = None
         env: Dict[str, str] = None
 
-    def patched_subprocess(command, shell, env, *args, **kwargs):
+    def patched_subprocess(command, env, *args, **kwargs):
         Results.command = command
         Results.env = env
         return subprocess.CompletedProcess(command, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,7 +167,7 @@ def test__getCli__run__mult_launcher(monkeypatch, data_dir, capfd):
     monkeypatch.setenv(kloch.Environ.CONFIG_PROFILE_ROOTS, str(data_dir))
     # needed to resolve 'python_file: test-script-a.py' in profile
     monkeypatch.chdir(data_dir)
-    argv = ["run", "mult-launchers", "--launcher", "@python"]
+    argv = ["run", "mult-launchers", "--launcher", "#python"]
     cli = kloch.get_cli(argv=argv)
     with pytest.raises(SystemExit, match="0"):
         cli.execute()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -160,4 +160,4 @@ def test_e2e_case3(data_dir, monkeypatch, tmp_path):
     print(result.stdout)
     print(result.stderr, file=sys.stderr)
     assert not result.returncode
-    assert '"hello from" test_e2e_case3' in result.stdout
+    assert result.stdout.strip("\n").endswith("hello from test_e2e_case3")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -118,7 +118,7 @@ def test_e2e_case2(data_dir, monkeypatch, tmp_path):
     assert not list(cwd_dir.glob("*"))
 
 
-def test_e2e_case3(data_dir, monkeypatch, tmp_path, capfd):
+def test_e2e_case3(data_dir, monkeypatch, tmp_path):
     """
     Use environ to define kloch config and test profile prodml
     """
@@ -150,7 +150,13 @@ def test_e2e_case3(data_dir, monkeypatch, tmp_path, capfd):
         "--",
         "test_e2e_case3",
     ]
-    result = subprocess.run(command, cwd=cwd_dir, env=environ)
+    result = subprocess.run(
+        command,
+        cwd=cwd_dir,
+        env=environ,
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
     assert not result.returncode
-    captured = capfd.readouterr()
-    assert '"hello from" test_e2e_case3' in captured.out
+    assert '"hello from" test_e2e_case3' in result.stdout

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -22,7 +22,7 @@ def test_e2e_case1(data_dir, monkeypatch, tmp_path):
     session_dir = tmp_path / "session"
 
     environ = os.environ.copy()
-    pythonpath = os.environ.get('PYTHONPATH')
+    pythonpath = os.environ.get("PYTHONPATH")
     if pythonpath:
         environ["PYTHONPATH"] = f"{pythonpath}{os.pathsep}{plugin_path}"
     else:
@@ -56,6 +56,21 @@ def test_e2e_case1(data_dir, monkeypatch, tmp_path):
     assert not result.returncode
     assert not list(cwd_dir.glob("*"))
 
+    profile_path = test_data_dir / "profile.prod.yml"
+
+    command = [
+        sys.executable,
+        "-m",
+        "kloch",
+        "run",
+        str(profile_path),
+        "--debug",
+        "--",
+        "testcommand",
+    ]
+    result = subprocess.run(command, cwd=cwd_dir, env=environ)
+    assert not result.returncode
+
 
 def test_e2e_case2(data_dir, monkeypatch, tmp_path):
     """
@@ -68,7 +83,7 @@ def test_e2e_case2(data_dir, monkeypatch, tmp_path):
     session_dir = tmp_path / "session"
 
     environ = os.environ.copy()
-    pythonpath = os.environ.get('PYTHONPATH')
+    pythonpath = os.environ.get("PYTHONPATH")
     if pythonpath:
         environ["PYTHONPATH"] = f"{pythonpath}{os.pathsep}{plugin_path}"
     else:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -158,5 +158,6 @@ def test_e2e_case3(data_dir, monkeypatch, tmp_path):
         text=True,
     )
     print(result.stdout)
+    print(result.stderr, file=sys.stderr)
     assert not result.returncode
     assert '"hello from" test_e2e_case3' in result.stdout

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -146,7 +146,7 @@ def test_e2e_case3(data_dir, monkeypatch, tmp_path):
         "prodml",
         "--debug",
         "--launcher",
-        "system",
+        ".system",
         "--",
         "test_e2e_case3",
     ]

--- a/tests/test_launchers_context.py
+++ b/tests/test_launchers_context.py
@@ -1,0 +1,64 @@
+import dataclasses
+
+from kloch.launchers._context import LauncherContext
+from kloch.launchers._context import LauncherPlatform
+from kloch.launchers._context import unserialize_context_expression
+from kloch.launchers._context import resolve_context_expression
+
+
+def test__ProfileContext():
+
+    ctx1 = LauncherContext(platform=LauncherPlatform.linux, user="unittest")
+    ctx2 = LauncherContext(platform=LauncherPlatform.linux, user="unittest")
+    assert ctx1 == ctx2
+
+    ctx3 = LauncherContext(platform=LauncherPlatform.linux)
+    assert ctx1 == ctx3
+
+    ctx4 = LauncherContext(platform=LauncherPlatform.windows)
+    assert ctx1 != ctx4
+
+    assert LauncherContext.create_from_system() == LauncherContext.create_from_system()
+
+
+def test__ProfileContext__devmistake():
+    for field in dataclasses.fields(LauncherContext):
+        assert "unserialize" in field.metadata
+        assert "serialized_name" in field.metadata
+        assert "doc" in field.metadata
+        assert "value" in field.metadata["doc"]
+        assert "description" in field.metadata["doc"]
+
+
+def test__unserialize_context_expression():
+    source = "he!$69@os=windows"
+    result = unserialize_context_expression(source)
+    assert result.platform == LauncherPlatform.windows
+    assert result.user is None
+
+    source = "he!$69@os=windows@user=babos@@mik"
+    result = unserialize_context_expression(source)
+    assert result.platform == LauncherPlatform.windows
+    assert result.user == "babos@mik"
+
+    source = "wow@@gmail.com"
+    result = unserialize_context_expression(source)
+    assert result.platform is None
+    assert result.user is None
+
+
+def test__resolve_context_expression():
+    source = "he!$69@os=windows"
+    result = resolve_context_expression(source)
+    expected = "he!$69"
+    assert result == expected
+
+    source = "he!$69@os=windows@user=babos@@mik"
+    result = resolve_context_expression(source)
+    expected = "he!$69"
+    assert result == expected
+
+    source = "wow@@gmail.com"
+    result = resolve_context_expression(source)
+    expected = "wow@gmail.com"
+    assert result == expected

--- a/tests/test_launchers_serialized.py
+++ b/tests/test_launchers_serialized.py
@@ -3,6 +3,8 @@ import logging
 import kloch.launchers
 from kloch.launchers import LauncherSerializedDict
 from kloch.launchers import LauncherSerializedList
+from kloch.launchers import LauncherContext
+from kloch.launchers import LauncherPlatform
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +30,88 @@ def test__LauncherSerializedDict():
     assert launchers[0]["python_file"] == "/foo"
     assert isinstance(launchers[1], kloch.launchers.BaseLauncherSerialized)
     assert launchers[1]["environ"]["PATH"] == ["$PATH", "/foo/bar"]
+
+
+def test__LauncherSerializedDict__filter():
+    launcher_serial = LauncherSerializedDict(
+        {
+            "system@os=windows": {
+                "command": "powershell script.ps1",
+            },
+            "system@os=linux": {
+                "command": "bash script.sh",
+            },
+            ".base": {
+                "environ": {
+                    "PATH": ["$PATH", "/foo/bar"],
+                    "PROD": "unittest",
+                },
+            },
+        },
+    )
+    context = LauncherContext(platform=LauncherPlatform.windows)
+    result = launcher_serial.get_filtered_context(context)
+    assert result is not launcher_serial
+    assert "system@os=linux" in launcher_serial
+    assert "system@os=linux" not in result
+    assert "system@os=windows" in result
+    assert ".base" in result
+
+    launcher_serial = LauncherSerializedDict(
+        {
+            ".base@user=tester": {
+                "envion": {"TESTING": "1"},
+            },
+            ".base": {
+                "environ": {
+                    "PATH": ["$PATH", "/foo/bar"],
+                    "PROD": "unittest",
+                },
+            },
+        },
+    )
+    context = LauncherContext(platform=LauncherPlatform.windows, user="tester")
+    result = launcher_serial.get_filtered_context(context)
+    assert ".base@user=tester" in result
+    assert ".base" in result
+
+
+def test__LauncherSerializedDict__with_context_resolved():
+    launcher_serial = LauncherSerializedDict(
+        {
+            "system@os=windows": {
+                "command": "powershell script.ps1",
+            },
+            "system@os=linux": {
+                "!=command": "bash script.sh",
+            },
+            ".base@user=tester": {
+                "environ": {"TESTING": "1"},
+            },
+            ".base": {
+                "environ": {
+                    "PATH": ["$PATH", "/foo/bar"],
+                    "PROD": "unittest",
+                },
+            },
+        },
+    )
+    expected = LauncherSerializedDict(
+        {
+            "system": {
+                "command": "powershell script.ps1",
+            },
+            ".base": {
+                "environ": {
+                    "TESTING": "1",
+                    "PATH": ["$PATH", "/foo/bar"],
+                    "PROD": "unittest",
+                },
+            },
+        },
+    )
+    result = launcher_serial.with_context_resolved()
+    assert result == expected
 
 
 def test__LauncherSerializedList():

--- a/tests/test_launchers_serialized.py
+++ b/tests/test_launchers_serialized.py
@@ -35,10 +35,10 @@ def test__LauncherSerializedDict():
 def test__LauncherSerializedDict__filter():
     launcher_serial = LauncherSerializedDict(
         {
-            "system@os=windows": {
+            ".system@os=windows": {
                 "command": "powershell script.ps1",
             },
-            "system@os=linux": {
+            ".system@os=linux": {
                 "command": "bash script.sh",
             },
             ".base": {
@@ -52,9 +52,9 @@ def test__LauncherSerializedDict__filter():
     context = LauncherContext(platform=LauncherPlatform.windows)
     result = launcher_serial.get_filtered_context(context)
     assert result is not launcher_serial
-    assert "system@os=linux" in launcher_serial
-    assert "system@os=linux" not in result
-    assert "system@os=windows" in result
+    assert ".system@os=linux" in launcher_serial
+    assert ".system@os=linux" not in result
+    assert ".system@os=windows" in result
     assert ".base" in result
 
     launcher_serial = LauncherSerializedDict(
@@ -79,10 +79,10 @@ def test__LauncherSerializedDict__filter():
 def test__LauncherSerializedDict__with_context_resolved():
     launcher_serial = LauncherSerializedDict(
         {
-            "system@os=windows": {
+            ".system@os=windows": {
                 "command": "powershell script.ps1",
             },
-            "system@os=linux": {
+            ".system@os=linux": {
                 "!=command": "bash script.sh",
             },
             ".base@user=tester": {
@@ -98,7 +98,7 @@ def test__LauncherSerializedDict__with_context_resolved():
     )
     expected = LauncherSerializedDict(
         {
-            "system": {
+            ".system": {
                 "command": "powershell script.ps1",
             },
             ".base": {

--- a/tests/test_launchers_serialized.py
+++ b/tests/test_launchers_serialized.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 def test__LauncherSerializedDict():
     launcher_serial = LauncherSerializedDict(
         {
-            "+=#python": {
+            "+=.python": {
                 "python_file": "/foo",
             },
             ".base": {

--- a/tests/test_launchers_serialized.py
+++ b/tests/test_launchers_serialized.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 def test__LauncherSerializedDict():
     launcher_serial = LauncherSerializedDict(
         {
-            "+=@python": {
+            "+=#python": {
                 "python_file": "/foo",
             },
             ".base": {


### PR DESCRIPTION
### added

- context system: allow to specify suffix tokens on launchers name to filter
  their visiblity based on the system context on runtime.
- cli: allow to specify profile to run/resolve as file paths

### changed

- ! `@python` launcher renamed to `.python` because of the new context system
- ! `system` launcher renamed to `.system` for cohesion
  - updated profile version to 4
- ! system launcher: add subprocess_kwargs field, shell=True is not default anymore.
- improve error reporting when a launcher is invalid
- minor logging improvements

### fixed

- issues when picking a launcher through multiple in a profile
